### PR TITLE
Add .htaccess to disallow direct access from web

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,2 @@
+Options -Indexes
+Deny from all


### PR DESCRIPTION
As RockShell currently needs to live within the webroot - it is accessible over the web.

This adds a .htaccess file to block things on Apache.