### PR TITLE
Symfony Console Migration

### DIFF
--- a/App/Commands/DbDownload.php
+++ b/App/Commands/DbDownload.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 class DbDownload extends Command
 {
+  use Concerns\RequiresProcessWire;
 
   const backupdir = "/site/assets/backups/database/";
 
@@ -32,7 +33,7 @@ class DbDownload extends Command
 
   public function handle()
   {
-    $wire = $this->wire();
+    $wire = $this->requireProcessWire(); // Get ProcessWire or exit
 
     // get remotes from config
     $remotes = $this->getConfig('remotes');

--- a/App/Commands/DbDump.php
+++ b/App/Commands/DbDump.php
@@ -8,6 +8,7 @@ use function ProcessWire\wireBytesStr;
 
 class DbDump extends Command
 {
+  use Concerns\RequiresProcessWire;
 
   const backupdir = "/site/assets/backups/database/";
 
@@ -32,7 +33,7 @@ class DbDump extends Command
 
   public function handle()
   {
-    $wire = $this->wire();
+    $wire = $this->requireProcessWire(); // Get ProcessWire or exit
     $file = $this->option("file");
 
     // delete all users except guest

--- a/App/Commands/DbPull.php
+++ b/App/Commands/DbPull.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 class DbPull extends Command
 {
+  use Concerns\RequiresProcessWire;
 
   const backupdir = "/site/assets/backups/database/";
 
@@ -33,7 +34,7 @@ class DbPull extends Command
 
   public function handle()
   {
-    $wire = $this->wire();
+    $wire = $this->requireProcessWire(); // Get ProcessWire or exit
 
     // get remotes from config
     $remotes = $this->getConfig('remotes');

--- a/App/Commands/DbRestore.php
+++ b/App/Commands/DbRestore.php
@@ -4,6 +4,7 @@ use ProcessWire\User;
 use Symfony\Component\Console\Input\InputOption;
 
 class DbRestore extends Command {
+  use Concerns\RequiresProcessWire;
 
   const backupdir = "/site/assets/backups/database/";
 
@@ -21,7 +22,7 @@ class DbRestore extends Command {
   }
 
   public function handle() {
-    $wire = $this->wire();
+    $wire = $this->requireProcessWire(); // Get ProcessWire or exit
     $file = $this->option("file");
 
     // confirm

--- a/App/Commands/Ddevadmin.php
+++ b/App/Commands/Ddevadmin.php
@@ -6,6 +6,7 @@ use Symfony\Component\Console\Input\InputArgument;
 
 class Ddevadmin extends Command
 {
+  use Concerns\RequiresProcessWire;
 
   public function config()
   {

--- a/App/Commands/FilesCleanup.php
+++ b/App/Commands/FilesCleanup.php
@@ -7,6 +7,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 class FilesCleanup extends Command
 {
+  use Concerns\RequiresProcessWire;
 
   public function config()
   {
@@ -18,7 +19,9 @@ class FilesCleanup extends Command
 
   public function handle()
   {
-    $path = $this->wire()->config->paths->files;
+    $wire = $this->requireProcessWire(); // Get ProcessWire or exit
+    
+    $path = $wire->config->paths->files;
     $dir = new DirectoryIterator($path);
 
     $this->write($this->option("show"));
@@ -35,10 +38,10 @@ class FilesCleanup extends Command
       if (!$d->isDir()) continue;
       $id = $d->getFilename();
       $folder = $d->getPath() . "/$id";
-      $files = $this->wire()->files->find($folder, [
+      $files = $wire->files->find($folder, [
         'returnRelative' => true,
       ]);
-      $page = $this->wire()->pages->get($id);
+      $page = $wire->pages->get($id);
       if ($page->id) {
         if (!$showExisting) continue;
         $this->success($folder);
@@ -49,7 +52,7 @@ class FilesCleanup extends Command
           $this->write("  " . implode("\n  ", $files));
         }
         if ($delete) {
-          $this->wire()->files->rmdir($folder, true);
+          $wire->files->rmdir($folder, true);
           $this->write("-- deleted --");
         }
         $this->write("");

--- a/App/Commands/ModuleInstall.php
+++ b/App/Commands/ModuleInstall.php
@@ -11,6 +11,7 @@ use function ProcessWire\wire;
  */
 class ModuleInstall extends Command
 {
+  use Concerns\RequiresProcessWire;
 
   public function config()
   {
@@ -20,15 +21,17 @@ class ModuleInstall extends Command
 
   public function handle()
   {
+    $wire = $this->requireProcessWire(); // Get ProcessWire or exit
+    
     // check name
     $name = $this->option('name');
     while (!$name) $name = $this->ask("Please enter the module's name");
 
-    wire()->modules->refresh();
+    $wire->modules->refresh();
 
     // special case for RockMigrations
     if ($name == 'RockMigrations') {
-      $rm = wire()->modules->get('RockMigrations');
+      $rm = $wire->modules->get('RockMigrations');
       if (!$rm) {
         $this->error("RockMigrations module not found");
         return self::FAILURE;
@@ -37,7 +40,7 @@ class ModuleInstall extends Command
     }
 
     // load RockMigrations
-    $rm = wire()->modules->get('RockMigrations');
+    $rm = $wire->modules->get('RockMigrations');
     if (!$rm) {
       $this->error("RockMigrations module not found");
       return self::FAILURE;

--- a/App/Commands/PwInstall.php
+++ b/App/Commands/PwInstall.php
@@ -112,10 +112,10 @@ class PwInstall extends Command
       $this->exec("wget --quiet $zip");
       $this->write('Extracting files ...');
       $this->exec('unzip -q site-rockfrontend.zip');
-      $this->nextStep(true, true);
-      return;
+      $this->nextStep(true, true);      return;
     }
 
+    $this->newLine();
     $this->write("Install site profile ...");
 
     $profiles = $this->browser
@@ -175,9 +175,9 @@ class PwInstall extends Command
       $this->browser->submitForm('Continue to Next Step');
     }
   }
-
   public function stepDatabase()
   {
+    $this->newLine();
     $this->write("Setting the following sections:");
     $this->browser->getCrawler()->filter('h2')->each(function (Crawler $el) {
       $this->write("  " . $el->text());
@@ -192,9 +192,7 @@ class PwInstall extends Command
       'debugMode' => 0, // will be enabled in config-local.php
     ]);
     $this->browser->submitForm('Continue', $form->getValues());
-  }
-
-  public function stepAdmin()
+  }  public function stepAdmin()
   {
     $this->write("Setup admin panel and user");
     $form = $this->fillForm([
@@ -412,8 +410,7 @@ class PwInstall extends Command
           'ignore',
         ], 0);
         $this->warn("\ndbTablesAction: $value"); // show always
-        $skipAll = true;
-      } else {
+        $skipAll = true;      } else {
         $value = $this->askWithCompletion($name, $options, $default);
         if ($this->output->isVerbose()) $this->write("$name=$value");
       }

--- a/App/Commands/PwRefresh.php
+++ b/App/Commands/PwRefresh.php
@@ -4,6 +4,7 @@ namespace RockShell;
 
 class PwRefresh extends Command
 {
+  use Concerns\RequiresProcessWire;
 
   public function config()
   {
@@ -13,7 +14,8 @@ class PwRefresh extends Command
 
   public function handle()
   {
-    $this->wire()->modules->refresh();
+    $wire = $this->requireProcessWire(); // Get ProcessWire or exit
+    $wire->modules->refresh();
     return self::SUCCESS;
   }
 }

--- a/App/Commands/PwSetup.php
+++ b/App/Commands/PwSetup.php
@@ -4,6 +4,7 @@ namespace RockShell;
 
 class PwSetup extends Command
 {
+  use Concerns\RequiresProcessWire;
 
   public function config()
   {
@@ -13,6 +14,8 @@ class PwSetup extends Command
 
   public function handle()
   {
+    $wire = $this->requireProcessWire(); // Get ProcessWire or exit
+
     // add gitignore
     $this->write('Updating .gitignore ...');
     $dst = $this->app->docroot() . ".gitignore";
@@ -29,12 +32,12 @@ class PwSetup extends Command
     }
 
     // add config-local.php
-    $localConfig = $this->wire()->config->paths->site . "config-local.php";
+    $localConfig = $wire->config->paths->site . "config-local.php";
     if (!is_file($localConfig) and $this->confirm("Split config into config.php and config-local.php?", true)) {
       $this->warn('Adding config-local.php ...');
 
       $src = $this->stub('config-local.php');
-      $config = $this->wire()->config;
+      $config = $wire->config;
       $this->stubPopulate($src, $localConfig, [
         'host' => $config->httpHost,
         'userAuthSalt' => $config->userAuthSalt,
@@ -65,9 +68,9 @@ class PwSetup extends Command
       exit(1);
     }
 
-    if (!$this->wire()->modules->isInstalled("RockMigrations")) {
+    if (!$wire->modules->isInstalled("RockMigrations")) {
       $this->warn("You can now install RockMigrations...");
-      $path = $this->wire()->config->paths->root . "site/modules";
+      $path = $wire->config->paths->root . "site/modules";
 
       $this->write("To add it as git submodule in a DDEV setup execute this command:");
       $this->question("git submodule add git@github.com:baumrock/RockMigrations.git site/modules/RockMigrations");
@@ -78,9 +81,9 @@ class PwSetup extends Command
 
       if ($this->confirm("Did you download RockMigrations and want to install it?", true)) {
         $this->write("Refreshing modules...");
-        $this->wire()->modules->refresh();
+        $wire->modules->refresh();
         $this->write("Installing RockMigrations...");
-        $this->wire()->modules->install("RockMigrations");
+        $wire->modules->install("RockMigrations");
       }
     }
 

--- a/App/Commands/PwUsers.php
+++ b/App/Commands/PwUsers.php
@@ -4,6 +4,7 @@ namespace RockShell;
 
 class PwUsers extends Command
 {
+  use Concerns\RequiresProcessWire;
 
   public function config()
   {
@@ -13,7 +14,9 @@ class PwUsers extends Command
 
   public function handle()
   {
-    foreach ($this->wire()->users as $u) {
+    $wire = $this->requireProcessWire(); // Get ProcessWire or exit
+    
+    foreach ($wire->users as $u) {
       $this->write("  {$u->name} [$u]");
     }
     return self::SUCCESS;

--- a/App/Commands/UserDelete.php
+++ b/App/Commands/UserDelete.php
@@ -6,6 +6,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 class UserDelete extends Command
 {
+  use Concerns\RequiresProcessWire;
 
   public function config()
   {
@@ -16,14 +17,16 @@ class UserDelete extends Command
 
   public function handle()
   {
+    $wire = $this->requireProcessWire(); // Get ProcessWire or exit
+
     if (!$user = $this->option('user')) {
       $users = [];
-      foreach ($this->wire()->users as $u) $users[] = $u->name;
+      foreach ($wire->users as $u) $users[] = $u->name;
       $user = $this->choice("Select user", $users);
     }
 
-    $user = $this->wire()->users->get("name=$user");
-    $this->wire()->users->delete($user);
+    $user = $wire->users->get("name=$user");
+    $wire->users->delete($user);
 
     $this->success("{$user->name} has been deleted.");
     return self::SUCCESS;

--- a/App/Commands/UserPass.php
+++ b/App/Commands/UserPass.php
@@ -7,6 +7,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 class UserPass extends Command
 {
+  use Concerns\RequiresProcessWire;
 
   public function config()
   {
@@ -17,9 +18,11 @@ class UserPass extends Command
 
   public function handle()
   {
+    $wire = $this->requireProcessWire(); // Get ProcessWire or exit
+
     if (!$user = $this->option('user')) {
       $users = [];
-      foreach ($this->wire()->users as $u) $users[] = $u->name;
+      foreach ($wire->users as $u) $users[] = $u->name;
       $user = $this->choice("Select user", $users);
     }
 
@@ -30,7 +33,7 @@ class UserPass extends Command
     ]);
     $pass = $this->ask("Enter Password", $pass);
 
-    $user = $this->wire()->users->get("name=$user");
+    $user = $wire->users->get("name=$user");
     $user->setAndSave('pass', $pass);
 
     $this->success("Password set for user " . $user->name . ".");

--- a/App/Commands/UserRename.php
+++ b/App/Commands/UserRename.php
@@ -6,6 +6,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 class UserRename extends Command
 {
+  use Concerns\RequiresProcessWire;
 
   public function config()
   {
@@ -17,21 +18,23 @@ class UserRename extends Command
 
   public function handle()
   {
+    $wire = $this->requireProcessWire(); // Get ProcessWire or exit
+    
     $users = [];
-    foreach ($this->wire()->users as $u) $users[] = $u->name;
+    foreach ($wire->users as $u) $users[] = $u->name;
 
     if (!$user = $this->option('user')) {
       $user = $this->choice("Select user", $users);
     }
 
     $name = $this->option('name');
-    $name = $this->wire()->sanitizer->pageName($name);
+    $name = $wire->sanitizer->pageName($name);
     while (!$name or in_array($name, $users)) {
       $name = $this->ask("Enter new username");
-      $name = $this->wire()->sanitizer->pageName($name);
+      $name = $wire->sanitizer->pageName($name);
     }
 
-    $user = $this->wire()->users->get("name=$user");
+    $user = $wire->users->get("name=$user");
     $this->success("User {$user->name} renamed to $name");
     $user->setAndSave('name', $name);
 

--- a/App/Commands/UserReset.php
+++ b/App/Commands/UserReset.php
@@ -7,6 +7,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 class UserReset extends Command
 {
+  use Concerns\RequiresProcessWire;
 
   public function config()
   {
@@ -19,9 +20,11 @@ class UserReset extends Command
 
   public function handle()
   {
+    $wire = $this->requireProcessWire(); // Get ProcessWire or exit
+
     if (!$user = $this->option('user')) {
       $users = [];
-      foreach ($this->wire()->users as $u) $users[] = $u->name;
+      foreach ($wire->users as $u) $users[] = $u->name;
       $user = $this->choice("Select user", $users);
     }
 
@@ -39,7 +42,7 @@ class UserReset extends Command
       $pass = $this->ask("Enter Password", $pass);
     }
 
-    $user = $this->wire()->users->get("name=$oldname");
+    $user = $wire->users->get("name=$oldname");
     $user->setAndSave('pass', $pass);
     $user->setAndSave('name', $newname);
 

--- a/App/Concerns/CallsCommands.php
+++ b/App/Concerns/CallsCommands.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace RockShell\Concerns;
+
+use Symfony\Component\Console\Input\ArrayInput;
+
+/**
+ * Trait for calling other commands
+ */
+trait CallsCommands
+{
+    /**
+     * Call another command
+     */
+    protected function call(string $command, array $arguments = [])
+    {
+        $application = $this->getApplication();
+        $command = $application->find($command);
+        
+        $input = new ArrayInput(array_merge(['command' => $command->getName()], $arguments));
+        return $command->run($input, $this->output);
+    }
+}

--- a/App/Concerns/HasParameters.php
+++ b/App/Concerns/HasParameters.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace RockShell\Concerns;
+
+/**
+ * Trait for accessing command parameters (options and arguments)
+ */
+trait HasParameters
+{
+    /**
+     * Get command option value
+     */
+    protected function option(string $name)
+    {
+        return $this->input->getOption($name);
+    }
+
+    /**
+     * Get command argument value
+     */
+    protected function argument(string $name)
+    {
+        return $this->input->getArgument($name);
+    }
+}

--- a/App/Concerns/InteractsWithIO.php
+++ b/App/Concerns/InteractsWithIO.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace RockShell\Concerns;
+
+/**
+ * Trait for handling input/output operations and styled messages
+ */
+trait InteractsWithIO
+{
+    /**
+     * Output info message
+     */
+    protected function info(string $message)
+    {
+        $this->output->writeln("<info>$message</info>");
+    }
+
+    /**
+     * Output error message
+     */
+    protected function error(string $message)
+    {
+        $this->output->writeln("<error>$message</error>");
+    }
+
+    /**
+     * Output warning message
+     */
+    protected function warn(string $message)
+    {
+        $this->output->writeln("<comment>$message</comment>");
+    }
+
+    /**
+     * Output alert message
+     */
+    protected function alert(string $message)
+    {
+        $length = strlen($message) + 4;
+        $border = str_repeat('*', $length);
+        
+        $this->output->writeln('');
+        $this->output->writeln("<comment>$border</comment>");
+        $this->output->writeln("<comment>*  $message  *</comment>");
+        $this->output->writeln("<comment>$border</comment>");
+        $this->output->writeln('');
+    }
+
+    /**
+     * Output comment message
+     */
+    protected function comment(string $message)
+    {
+        $this->output->writeln("<comment>$message</comment>");
+    }
+
+    /**
+     * Output question message
+     */
+    protected function question(string $message)
+    {
+        $this->output->writeln("<question>$message</question>");
+    }
+
+    /**
+     * Write success message to output
+     */
+    public function success($str)
+    {
+        $this->info($this->str($str));
+    }
+
+    /**
+     * Write string to output
+     */
+    public function write($str)
+    {
+        $str = $this->str($str);
+        $this->output->writeln($str);
+    }
+
+    /**
+     * Output a blank line
+     */
+    protected function newLine($count = 1)
+    {
+        for ($i = 0; $i < $count; $i++) {
+            $this->output->writeln('');
+        }
+    }
+}

--- a/App/Concerns/InteractsWithQuestions.php
+++ b/App/Concerns/InteractsWithQuestions.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace RockShell\Concerns;
+
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+/**
+ * Trait for handling user interaction and prompts
+ */
+trait InteractsWithQuestions
+{
+    /**
+     * Ask user for input
+     */
+    protected function ask(string $question, $default = null)
+    {
+        $helper = $this->getHelper('question');
+        $prompt = $default ? " [<comment>$default</comment>]" : '';
+        $question = new Question("\n <info>$question</info>$prompt:\n > ", $default);
+        return $helper->ask($this->input, $this->output, $question);
+    }
+
+    /**
+     * Ask user to choose from options
+     */
+    protected function choice(string $question, array $choices, $default = null)
+    {
+        $helper = $this->getHelper('question');
+        $defaultText = $default !== null ? " [$default]" : '';
+        $question = new ChoiceQuestion("\n <info>$question</info>$defaultText:", $choices, $default);
+        return $helper->ask($this->input, $this->output, $question);
+    }
+
+    /**
+     * Ask user for confirmation
+     */
+    protected function confirm(string $question, bool $default = true)
+    {
+        $helper = $this->getHelper('question');
+        $defaultText = $default ? 'yes' : 'no';
+        $question = new ConfirmationQuestion("\n <info>$question</info> (yes/no) [<comment>$defaultText</comment>]:\n > ", $default);
+        return $helper->ask($this->input, $this->output, $question);
+    }
+
+    /**
+     * Ask with autocomplete support
+     */
+    protected function askWithCompletion(string $question, array $autocomplete = [], $default = null)
+    {
+        $helper = $this->getHelper('question');
+        $prompt = $default !== null ? " [<comment>$default</comment>]" : '';
+        $question = new Question("\n <info>$question</info>$prompt:\n > ", $default);
+        if (!empty($autocomplete)) {
+            $question->setAutocompleterValues(array_values($autocomplete));
+        }
+        return $helper->ask($this->input, $this->output, $question);
+    }
+}

--- a/App/Concerns/RequiresProcessWire.php
+++ b/App/Concerns/RequiresProcessWire.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace RockShell\Concerns;
+
+/**
+ * Trait for commands that require ProcessWire to be available
+ */
+trait RequiresProcessWire
+{
+    /**
+     * Get ProcessWire instance or fail gracefully
+     */
+    protected function requireProcessWire()
+    {
+        $wire = $this->wire();
+        if (!$wire) {
+            $this->error("ProcessWire not found or not installed. Please run this command from an installed ProcessWire directory.");
+            exit(1); // Failure exit code
+        }
+        return $wire;
+    }
+}

--- a/Application.php
+++ b/Application.php
@@ -2,9 +2,7 @@
 
 namespace RockShell;
 
-use Illuminate\Console\Application as ConsoleApplication;
-use Illuminate\Container\Container;
-use Illuminate\Events\Dispatcher;
+use Symfony\Component\Console\Application as ConsoleApplication;
 
 require_once __DIR__ . "/App/Command.php";
 class Application extends ConsoleApplication
@@ -31,10 +29,7 @@ class Application extends ConsoleApplication
       $version = json_decode(file_get_contents(__DIR__ . "/package.json"))->version;
     }
     $version .= ' @ PHP' . phpversion();
-    $container = new Container;
-    $events = new Dispatcher($container);
-    parent::__construct($container, $events, $version);
-    $this->setName($name);
+    parent::__construct($name, $version);
     $this->root = $this->normalizeSeparators(dirname(__DIR__)) . "/";
     $this->docroot =
       rtrim($this->root . (getenv('DDEV_DOCROOT') ?: getenv('ROCKSHELL_DOCROOT')), "/") . "/";

--- a/composer.json
+++ b/composer.json
@@ -1,21 +1,24 @@
 {
-    "require": {
-        "illuminate/console": "^8.40",
-        "illuminate/events": "^8.40",
-        "symfony/browser-kit": "^5.4",
-        "symfony/css-selector": "^5.4",
-        "symfony/dom-crawler": "^5.4",
-        "symfony/http-client": "^5.4",
-        "symfony/mime": "^5.4"
-    },
-    "autoload": {
-        "files": [
-            "Application.php"
-        ]
-    },
-    "config": {
-        "platform": {
-            "php": "7.4.0"
-        }
+  "require": {
+    "symfony/console": "^7.0",
+    "symfony/browser-kit": "^7.0",
+    "symfony/css-selector": "^7.0",
+    "symfony/dom-crawler": "^7.0",
+    "symfony/http-client": "^7.0",
+    "symfony/mime": "^7.0"
+  },
+  "autoload": {
+    "files": [
+      "Application.php"
+    ],
+    "psr-4": {
+      "RockShell\\": "App/",
+      "RockShell\\Concerns\\": "App/Concerns/"
     }
+  },
+  "config": {
+    "platform": {
+      "php": "8.4.0"
+    }
+  }
 }


### PR DESCRIPTION
## **What changed?**
- **Dependencies**: `illuminate/console` → `symfony/console`
- **Architecture**: Moved helpers to focused traits (Laravel-style)
- **Error Handling**: ProcessWire commands now fail gracefully when PW isn't available
- **UX**: Preserved original styling and prompts (I hope)